### PR TITLE
Specify encoding

### DIFF
--- a/src/travis_wait_improved/sherpa.py
+++ b/src/travis_wait_improved/sherpa.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 """Helper tool to work around stdout timout of Travis-CI.
 


### PR DESCRIPTION
This should hopefully fix this bug that I encountered when using this script in Travis CI:

```
SyntaxError: Non-ASCII character '\xe2' in file /home/travis/.local/lib/python2.7/site-packages/travis_wait_improved/sherpa.py on line 29, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```